### PR TITLE
chore: postgres docker-compose configuration 🔧

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,39 @@
+version: '3.8'
+services:
+  postgres:
+    container_name: postgres
+    restart: unless-stopped
+    image: postgres:15.3
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-password}
+      PGDATA: /data/postgres
+    volumes:
+      - postgres:/data/postgres
+    ports:
+      - "5432:5432"
+    networks:
+      - postgres
+
+  pgadmin:
+    container_name: pgadmin
+    restart: unless-stopped
+    image: dpage/pgadmin4:latest
+    environment:
+      PGADMIN_DEFAULT_EMAIL: ${PGADMIN_DEFAULT_EMAIL:-john@doe.fr}
+      PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_DEFAULT_PASSWORD:-password}
+      PGADMIN_CONFIG_SERVER_MODE: 'False'
+    volumes:
+      - pgadmin:/var/lib/pgadmin
+    ports:
+      - "${PGADMIN_PORT:-5050}:80"
+    networks:
+      - postgres
+
+networks:
+  postgres:
+    driver: bridge
+
+volumes:
+  postgres:
+  pgadmin:


### PR DESCRIPTION
## Ticket
https://www.notion.so/ETQ-devops-JV-mettre-en-place-un-container-Docker-pour-la-DB-Postgres-45f1a5ec213d472881f53e607b2f26d8?pvs=4

## Info
- Start Postgres server and PGAdmin with `docker compose up -d`
- PGAdmin available at [`http://localhost:5050/`](http://localhost:5050/)
- Default PGAdmin password : `password`

## Register a new server
- Default user : `postgres`
- Default password : `password`
<img width="703" alt="image" src="https://github.com/MisterAzix/hetic-saline-royale-academy/assets/40914400/79821f91-42a1-4432-bec2-b51adc51e919">
